### PR TITLE
Removes the puritan trait from the game.

### DIFF
--- a/code/WorkInProgress/cloner_defects.dm
+++ b/code/WorkInProgress/cloner_defects.dm
@@ -361,17 +361,6 @@ ABSTRACT_TYPE(/datum/cloner_defect/organ_damage)
 						"count" = rand(3, 5))
 		..()
 
-/// You become a puritan- no more clonings for you! (unless the docs are really solid)
-/datum/cloner_defect/puritan
-	name = "Rapid-Onset Puritanism"
-	desc = "Subject has developed an incompatibility to cloning methods."
-	severity = CLONER_DEFECT_SEVERITY_MAJOR
-	stackable = FALSE
-
-	on_add()
-		. = ..()
-		owner.traitHolder.addTrait("puritan")
-
 /datum/cloner_defect/arm_swap //! Left and right arms are swapped, making them both initially useless TODO actually implement
 	name = "Limb Discombobulation"
 	desc = "Subject's legs have been grown where their arms are supposed to be. Location of their arms is unknown."

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -217,8 +217,6 @@
 
 		for(var/datum/mind/mind in to_search)
 			if((istype(mind.current, /mob/dead/observer) || isdead(mind.current)) && mind.current.client && !mind.get_player()?.dnr)
-				//prune puritan trait
-				mind.current?.traitHolder.removeTrait("puritan")
 				var/success = growclone(mind.current, mind.current.real_name, mind, mind.current?.bioHolder, traits=mind.current?.traitHolder.copy())
 				if (success && team)
 					SPAWN(1)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -847,14 +847,6 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "chemresist"
 	points = -2
 
-/datum/trait/puritan
-	name = "Puritan"
-	desc = "You can not be cloned or revived except by cyborgification. Any attempt will end badly."
-	id = "puritan"
-	points = 2
-	category = list("cloner_stuff")
-
-
 /datum/trait/survivalist
 	name = "Survivalist"
 	desc = "Food will heal you even if you are badly injured."

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -539,20 +539,13 @@ datum
 						var/mob/living/carbon/human/H = M
 						var/obj/item/organ/brain/B = H.organHolder?.get_organ("brain")
 						G = find_ghost_by_key(B?.owner?.key)
-						var/is_puritan = 0
-						if(ismob(G))
-							for (var/trait as anything in G?.client.preferences.traitPreferences.traits_selected)
-								if(trait == "puritan")
-									is_puritan = 1
-						if(H.traitHolder.hasTrait("puritan"))
-							is_puritan = 1
-						if (came_back_wrong || H.decomp_stage || G?.mind?.get_player()?.dnr || is_puritan) //Wire: added the dnr condition here
+						if (came_back_wrong || H.decomp_stage || G?.mind?.get_player()?.dnr) //Wire: added the dnr condition here
 							H.visible_message("<span class='alert'><B>[H]</B> starts convulsing violently!</span>")
 							if (G?.mind?.get_player()?.dnr)
 								H.visible_message("<span class='alert'><b>[H]</b> seems to prefer the afterlife!</span>")
 							H.make_jittery(1000)
 							SPAWN(rand(20, 100))
-								logTheThing(LOG_COMBAT, H, "is gibbed by puritan when resuscitated with strange reagent at [log_loc(H)].")
+								logTheThing(LOG_COMBAT, H, "is gibbed by when resuscitated with strange reagent at [log_loc(H)].")
 								H.gib()
 							return
 					else // else just get whoever's the mind

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -150,21 +150,21 @@
 	comtype = /obj/item/cloneModule/speedyclone
 	amount = 1
 	price_boundary = list(8000,12000)
-	possible_names = list("We have these new-fangled cloning upgrade modules lying around, but they are usless to our puritan crew.")
+	possible_names = list("We have these new-fangled cloning upgrade modules lying around.")
 
 /datum/commodity/trader/efficiencymodule
 	comname = "Cloning upgrade system"
 	comtype = /obj/item/cloneModule/efficientclone
 	amount = 1
 	price_boundary = list(8000,12000)
-	possible_names = list("We have these new-fangled cloning upgrade modules lying around, but they are useless to our puritan crew.")
+	possible_names = list("We have these new-fangled cloning upgrade modules lying around.")
 
 /datum/commodity/trader/dnamodule
 	comname = "Cloning upgrade system"
 	comtype = /obj/item/cloneModule/genepowermodule
 	amount = 1
 	price_boundary = list(8000,12000)
-	possible_names = list("We have these new-fangled cloning upgrade modules lying around, but they are useless to our puritan crew.")
+	possible_names = list("We have these new-fangled cloning upgrade modules lying around.")
 
 /datum/commodity/trader/ringtone_dogs
 	comname = "Wolf pack ringtone cartridge"

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -282,48 +282,7 @@ TYPEINFO(/obj/machinery/clonepod)
 		if (length(defects.active_cloner_defects) > 7)
 			src.occupant.unlock_medal("Quit Cloning Around")
 
-		src.mess = FALSE
-		var/is_puritan = FALSE
-		if (!isnull(traits) && src.occupant.traitHolder)
-			traits.copy_to(src.occupant.traitHolder)
-
-
-			#ifndef MAP_OVERRIDE_POD_WARS
-			if(src.occupant.traitHolder.hasTrait("puritan"))
-				is_puritan = TRUE
-
-			for (var/trait as anything in src.occupant?.client.preferences.traitPreferences.traits_selected)
-				if(trait == "puritan")
-					is_puritan = TRUE
-
-			if (is_puritan)
-				src.mess = TRUE
-				// Puritans have a bad time.
-				// This is a little different from how it was before:
-				// - Immediately take 250 tox and 100 random brute
-				// - 50% chance, per limb, to lose that limb
-				// - enforced premature_clone, which gibs you on death
-				// If you have a clone body that's been allowed to fully heal before
-				// cloning a puritan, you have a sliiiiiiiiiiight chance to get them
-				// out of deep critical health before they turn into chunky salsa
-				// This should be really rare to have happen, but I want to leave it in
-				// just in case someone manages to pull off a miracle save
-				src.occupant.bioHolder?.AddEffect("premature_clone")
-				src.occupant.take_toxin_damage(250)
-				random_brute_damage(src.occupant, 100, 0)
-				if (ishuman(src.occupant))
-					var/mob/living/carbon/human/P = src.occupant
-					if (P.limbs)
-						var/list/limbs = list("l_arm", "r_arm", "l_leg", "r_leg")
-						for (var/limb in limbs)
-							if (prob(50))
-								P.limbs.sever(limb)
-			#endif
-
-		if (src.mess)
-			boutput(src.occupant, "<span class='notice'><b>Clone generation process initi&mdash;</b></span><span class='alert'> oh fuck oh god oh no no NO <b>NO NO THIS IS NOT GOOD</b></span>")
-		else
-			boutput(src.occupant, "<span class='notice'><b>Clone generation process initiated.</b> This might take a moment, please hold.</span>")
+		boutput(src.occupant, "<span class='notice'><b>Clone generation process initiated.</b> This might take a moment, please hold.</span>")
 
 		if (clonename)
 			if (!src.perfect_clone && prob(15))
@@ -387,8 +346,7 @@ TYPEINFO(/obj/machinery/clonepod)
 		if (src.connected?.BE)
 			src.occupant.bioHolder.AddEffectInstance(src.connected.BE,1)
 
-		if (!is_puritan)
-			src.occupant.changeStatus("paralysis", 10 SECONDS)
+		src.occupant.changeStatus("paralysis", 10 SECONDS)
 		previous_heal = src.occupant.health
 #ifdef CLONING_IS_INSTANT
 		src.occupant.full_heal()
@@ -416,14 +374,6 @@ TYPEINFO(/obj/machinery/clonepod)
 
 		if (src.occupant && src.occupant.loc == src)
 			// If we have a body inside the pod right now...
-
-			if (src.occupant.traitHolder && src.occupant.traitHolder.hasTrait("puritan"))
-				// puritans get punted out immediately
-				src.go_out(1)
-				src.connected_message("Clone Aborted: Genetic Structure Incompatible.", "warning")
-				src.send_pda_message("Clone Aborted: Genetic Structure Incompatible")
-				power_usage = 200
-				return ..()
 
 			if (src.clonehack == 1 && prob(10))
 				// Mindhack cloning modules make obnoxious noises.

--- a/code/obj/mapping/mob_spawn.dm
+++ b/code/obj/mapping/mob_spawn.dm
@@ -92,7 +92,6 @@
 		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
 		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
 		H.death(FALSE)
-		H.traitHolder.addTrait("puritan")
 
 		if (src.no_decomp)
 			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -460,7 +460,6 @@ var/global/totally_random_jobs = FALSE
 			H.traitHolder.removeTrait("stowaway")
 			H.traitHolder.removeTrait("pilot")
 			H.traitHolder.removeTrait("sleepy")
-			H.traitHolder.removeTrait("puritan")
 
 		H.Equip_Job_Slots(JOB)
 

--- a/code/z_adventurezones/safehouse.dm
+++ b/code/z_adventurezones/safehouse.dm
@@ -281,12 +281,6 @@ obj/item/reagent_containers/iv_drip/dead_exec
 			if(!isnull(R))// Proceed if scan was a success or user has been scanned previously, our broadcast is interfering with the existing scan.
 				boutput(H,"Link to cloning computer establised succesfully.")
 				playsound(src.loc, 'sound/machines/ping.ogg', 50, 1)
-				var/has_puritan = FALSE
-				var/datum/traitHolder/traits = R["traits"]
-				if(traits.hasTrait("puritan")) //Does the user's clone record have puritan?
-					has_puritan = TRUE
-				if(prob(20) && !has_puritan) //If the scan doesn't have puritan, roll a dice. Too uncommon to weaponise too common for general use.
-					traits.addTrait("puritan") // Signal has degraded. Did the player learn nothing from the prefab??
 
 //DECORATIVE OBJECTS
 

--- a/strings/roundstart_hints.txt
+++ b/strings/roundstart_hints.txt
@@ -42,7 +42,7 @@ You can press V to equip clothing or place equipment on your belt slot if possib
 If you have WASD Mode enabled, you can drop items by pressing Q.
 Don't wanna be spontaneously naked and drop everything on the ground? Click the inventory button with your item to quick swap clothing and equipment.
 Death isn't the end! There are many ways to be brought back to life and many things to do while a ghost!
-The medical computer can list a person's traits; no more accidental puritan cloning!
+The medical computer can list a person's traits!
 Want to help? Geneticists might have an interest in checking your genes for cool stuff! Hop down to medical research.
 Are you done for and yet your body just keeps on living? Use the 'succumb' command to hasten your demise so you can start observing.
 Looking for a job? Go to the Head of Personnel's desk for a job change, or ask over the radio if you can be of help.


### PR DESCRIPTION
[TRAITS] [MEDICAL] [REMOVAL]

## About the PR

See title.

## Why's this needed?

The puritan trait is unnecessary when DNR exists and the main alternative method of post-mortem revival (cyborgification) is going to be removed.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(*)Removes the puritan trait in its entirety.
```