### PR TITLE
Automatically sets DNR when the "suicide" verb is used.

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -227,7 +227,7 @@
 				<a href="byond://winset?command=Ghost" style="display: inline-block; font-size: 130%; font-weight: bold;">Become a Ghost</a>
 				<br><em style="color: #666; font-size: 75%;">You can also use the "<a href="byond://winset?command=Ghost" style="font-family: 'Consolas', monospace;">Ghost</a>" command to observe.</em><br><br>
 			"} : ""]
-		<strong>You may be revived if someone clones you.</strong>
+		<strong>If you did not suicide or set DNR, you may be revived if someone clones you.</strong>
 		<br>Otherwise, you'll have to wait for the next round.
 		<br>
 		<br>There's still plenty to do, even while dead!

--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -54,6 +54,7 @@
 			return
 
 	if (src.do_suicide()) //                           <------ put mob unique behaviour here in an override!!!!
+		src.mind.get_player()?.dnr = TRUE
 		src.suiciding = TRUE
 		logTheThing(LOG_COMBAT, src, "commits suicide")
 		src.unlock_medal("Damned", 1) //You don't get the medal if you tried to wuss out!
@@ -83,6 +84,10 @@
 
 /mob/living/carbon/human/do_suicide()
 	src.unkillable = 0 //Get owned, nerd!
+
+	var/confirm = tgui_alert(src, "Warning, if you commit suicide you cannot be revived! Are you certain you wish to proceed?", "Confirm Suicide", list("Yes", "No"), 15 SECONDS)
+	if(confirm != "Yes")
+		return
 
 	var/list/suicides = list("hold your breath")
 	if (src.on_chair)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

DNR status is now automatically set when a player uses the "suicide" verb and a popup/choice confirm explaining this has been added.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Prevents abuse of the verb to grief doctors and others.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(*)The "suicide" verb sets DNR when it succeeds and requires additional confirmation.
(+)Slightly tweaks the info received on death.
```
