### PR TITLE
Slightly adjusts surgery failure values.

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -143,7 +143,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 
 	if (patient.reagents) // check for anesthetics/analgetics
 		if (patient.reagents.get_reagent_amount("morphine") >= 10)
-			screw_up_prob -= 10
+			screw_up_prob -= 15
 		if (patient.reagents.get_reagent_amount("haloperidol") >= 10)
 			screw_up_prob -= 10
 		if (patient.reagents.get_reagent_amount("ethanol") >= 5)
@@ -156,7 +156,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 	if (surgeon.traitHolder.hasTrait("training_medical"))
 		screw_up_prob = clamp(screw_up_prob, 0, 100) // if they're a doctor they can have no chance to mess up
 	else
-		screw_up_prob = clamp(screw_up_prob, 5, 100) // otherwise there'll always be a slight chance
+		screw_up_prob = clamp(screw_up_prob, 15, 100) // otherwise there'll always be a slight chance
 
 	DEBUG_MESSAGE("<b>[patient]'s surgery (performed by [surgeon]) has screw_up_prob set to [screw_up_prob]</b>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Buffs morphine's surgery failure chance reduction from 10 to 15.
Increases the minimum failure chance for untrained crew performing surgery from 5 to 15.

This means that doctors will get more value from morphine than their untrained counterparts. It also means they can fully eliminate failure risk using two accessible methods, rather than three being required.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These changes will hopefully encourage doctors to use failure chance reducing means more often which is good for RP/immersion and adds slightly more resource management to an otherwise basic role.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(+)Buffs morphine's surgery failure reducing ability.
(+)Increases the minimum chance of failure for untrained crew performing surgery.
```
