### PR TITLE
Adds a new trait - "One Eyed" - with two variants.

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -363,14 +363,14 @@
 					H.drop_organ("right_eye")
 					qdel(eyeball)
 
-	onRemove(var/mob/owner)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			if(H.organHolder != null)
-				if (H.organHolder.right_eye != null) //check to see if the eye has been replaced
-					return
-				else
-					H.receive_organ(/obj/item/organ/eye/right, "right_eye", 2, 0)
+					//give them an eyepatch
+					var/eyepatch = /obj/item/clothing/glasses/eyepatch
+					if (H.back?.storage && H.equip_if_possible(eyepatch, slot_in_backpack))
+
+					src.block_eye = "L"
+					src.icon_state = "eyepatch-L"
+
+	//to do: figure out some way of readding the eye when the trait is removed
 
 	one_eyed_l
 		name = "One Eyed (Left Eye Missing)"
@@ -384,15 +384,6 @@
 						var/eyeball = H.organHolder.left_eye
 						H.drop_organ("left_eye")
 						qdel(eyeball)
-
-		onRemove(var/mob/owner)
-			if(ishuman(owner))
-				var/mob/living/carbon/human/H = owner
-				if(H.organHolder != null)
-					if (H.organHolder.left_eye != null)
-						return
-					else
-						H.receive_organ(/obj/item/organ/eye/left, "left_eye", 2, 0)
 
 /datum/trait/blind
 	name = "Blind"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -283,6 +283,8 @@
 	category = list("body")
 	points = 0
 
+	//the limb removal component of this is currently in code/procs/jobprocs.dm; same for one armed
+
 /datum/trait/explolimbs
 	name = "Adamantium Skeleton"
 	desc = "Halves the chance that an explosion will blow off your limbs."
@@ -368,7 +370,7 @@
 				if (H.organHolder.right_eye != null) //check to see if the eye has been replaced
 					return
 				else
-					H.receive_organ(/obj/item/organ/eye/right, "right_eye", 0, 1)
+					H.receive_organ(/obj/item/organ/eye/right, "right_eye", 2, 0)
 
 	one_eyed_l
 		name = "One Eyed (Left Eye Missing)"
@@ -390,7 +392,7 @@
 					if (H.organHolder.left_eye != null)
 						return
 					else
-						H.receive_organ(/obj/item/organ/eye/left, "left_eye", 0, 1)
+						H.receive_organ(/obj/item/organ/eye/left, "left_eye", 2, 0)
 
 /datum/trait/blind
 	name = "Blind"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -268,6 +268,21 @@
 					H.limbs.r_arm.holder = H
 					H.update_body()
 
+/datum/trait/one_armed //relocated from trinkets category
+	name = "One Armed Spaceman"
+	desc = "You only have one arm. But which one? It's a mystery... or is it a thriller?"
+	id = "onearmed"
+	icon_state = "placeholder"
+	points = 0
+
+/datum/trait/nolegs
+	name = "Stumped"
+	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair out of the goodness of their heart. (due to regulations)"
+	id = "nolegs"
+	icon_state = "placeholder"
+	category = list("body")
+	points = 0
+
 /datum/trait/explolimbs
 	name = "Adamantium Skeleton"
 	desc = "Halves the chance that an explosion will blow off your limbs."
@@ -280,7 +295,7 @@
 	desc = "Spawn with permanent deafness and an auditory headset."
 	id = "deaf"
 	icon_state = "deaf"
-	category = list("body")
+	category = list("vision") //moved because of the header
 	points = 1
 
 	onAdd(var/mob/owner)
@@ -291,14 +306,6 @@
 	onLife(var/mob/owner) //Just to be super safe.
 		if(!owner.ear_disability)
 			owner.bioHolder.AddEffect("deaf", 0, 0, 0, 1)
-
-/datum/trait/nolegs
-	name = "Stumped"
-	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair out of the goodness of their heart. (due to regulations)"
-	id = "nolegs"
-	icon_state = "placeholder"
-	category = list("body")
-	points = 0
 
 // VISION/SENSES - Green Border
 
@@ -335,6 +342,39 @@
 	onLife(var/mob/owner) //Just to be super safe.
 		if(owner.bioHolder && !owner.bioHolder.HasEffect("bad_eyesight"))
 			owner.bioHolder.AddEffect("bad_eyesight", 0, 0, 0, 1)
+
+/datum/trait/one_eyed
+	name = "One Eyed (Right Eye Missing)"
+	desc = "No, you aren't a cyclops, but you are down one eye."
+	id = "one_eyed"
+	icon_state =  "placeholder"
+	category = list("vision")
+	points = 1
+	afterlife_blacklisted = TRUE
+
+	onAdd(var/mob/owner)
+		SPAWN(4 SECONDS)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/H = owner
+				if(H.organHolder != null)
+					var/eyeball = H.organHolder.get_organ("right eye")
+					H.drop_organ(eyeball)
+					H.update_body()
+					qdel(eyeball)
+
+	/*one_eyed_l
+		name = "One Eyed (Left Eye Missing)"
+		id = "one_eyed_l"
+
+		onAdd(var/mob/owner)
+			SPAWN(4 SECONDS)
+				if(ishuman(owner))
+					var/mob/living/carbon/human/H = owner
+					if(H.organHolder != null)
+						var/eyeball = H.organHolder.get_organ("left eye")
+						H.drop_organ(eyeball)
+						H.update_body()
+						qdel(eyeball)*/
 
 /datum/trait/blind
 	name = "Blind"
@@ -437,15 +477,6 @@
 	icon_state = "placeholder"
 	points = 0
 	category = list("trinkets", "nopug")
-
-/datum/trait/one_armed
-	name = "One Armed Spaceman"
-	desc = "You only have one arm. But which one? It's a mystery... or is it a thriller?"
-	id = "onearmed"
-	icon_state = "placeholder"
-	points = 0
-
-
 
 // Skill - White Border
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -368,7 +368,7 @@
 				if (H.organHolder.right_eye != null) //check to see if the eye has been replaced
 					return
 				else
-					H.receive_organ(/obj/item/organ/eye, "right_eye", 0, 1)
+					H.receive_organ(/obj/item/organ/eye/right, "right_eye", 0, 1)
 
 	one_eyed_l
 		name = "One Eyed (Left Eye Missing)"
@@ -390,7 +390,7 @@
 					if (H.organHolder.left_eye != null)
 						return
 					else
-						H.receive_organ(/obj/item/organ/eye, "left_eye", 0, 1)
+						H.receive_organ(/obj/item/organ/eye/left, "left_eye", 0, 1)
 
 /datum/trait/blind
 	name = "Blind"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -347,7 +347,7 @@
 
 /datum/trait/one_eyed
 	name = "One Eyed (Right Eye Missing)"
-	desc = "No, you aren't a cyclops, but you are down one eye."
+	desc = "No, you aren't a cyclops, but you are down one eye. On the brightside, you start with an eyepatch."
 	id = "one_eyed"
 	icon_state =  "placeholder"
 	category = list("vision")
@@ -391,11 +391,8 @@
 						qdel(eyeball)
 
 						var/eyepatch = /obj/item/clothing/glasses/eyepatch
-						/*eyepatch.block_eye = "L"
-						eyepatch.icon_state = "eyepatch-L"*/
-						if (H.equip_new_if_possible(eyepatch, H.slot_glasses))
-							return
-						else if (H.equip_new_if_possible(eyepatch, H.slot_l_hand))
+						//attempted to get this to correctly equip to the eye slot, flipping itself in the process, but couldn't get it working
+						if (H.equip_new_if_possible(eyepatch, H.slot_l_hand))
 							return
 						else if (H.equip_new_if_possible(eyepatch, H.slot_r_hand))
 							return

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -357,10 +357,7 @@
 			if(ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				if(H.organHolder != null)
-					var/eyeball = H.organHolder.get_organ("right eye")
-					H.drop_organ(eyeball)
-					H.update_body()
-					qdel(eyeball)
+					H.drop_organ("right eye")
 
 	/*one_eyed_l
 		name = "One Eyed (Left Eye Missing)"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -365,8 +365,15 @@
 
 					//give them an eyepatch
 					var/eyepatch = /obj/item/clothing/glasses/eyepatch
-					if (H.back?.storage)
-						H.back.storage += new eyepatch(src)
+					if (H.equip_new_if_possible(eyepatch, H.slot_glasses))
+						return
+					else if (H.equip_new_if_possible(eyepatch, H.slot_l_hand))
+						return
+					else if (H.equip_new_if_possible(eyepatch, H.slot_r_hand))
+						return
+					else
+						new eyepatch(H.loc)
+
 
 	//to do: figure out some way of readding the eye when the trait is removed
 
@@ -383,8 +390,17 @@
 						H.drop_organ("left_eye")
 						qdel(eyeball)
 
-						//src.block_eye = "L"
-						//src.icon_state = "eyepatch-L"
+						var/eyepatch = /obj/item/clothing/glasses/eyepatch
+						/*eyepatch.block_eye = "L"
+						eyepatch.icon_state = "eyepatch-L"*/
+						if (H.equip_new_if_possible(eyepatch, H.slot_glasses))
+							return
+						else if (H.equip_new_if_possible(eyepatch, H.slot_l_hand))
+							return
+						else if (H.equip_new_if_possible(eyepatch, H.slot_r_hand))
+							return
+						else
+							new eyepatch(H.loc)
 
 /datum/trait/blind
 	name = "Blind"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -295,7 +295,7 @@
 	desc = "Spawn with permanent deafness and an auditory headset."
 	id = "deaf"
 	icon_state = "deaf"
-	category = list("vision") //moved because of the header
+	category = list("body")
 	points = 1
 
 	onAdd(var/mob/owner)
@@ -357,9 +357,20 @@
 			if(ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				if(H.organHolder != null)
-					H.drop_organ("right eye")
+					var/eyeball = H.organHolder.right_eye
+					H.drop_organ("right_eye")
+					qdel(eyeball)
 
-	/*one_eyed_l
+	onRemove(var/mob/owner)
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			if(H.organHolder != null)
+				if (H.organHolder.right_eye != null) //check to see if the eye has been replaced
+					return
+				else
+					H.receive_organ(/obj/item/organ/eye, "right_eye", 0, 1)
+
+	one_eyed_l
 		name = "One Eyed (Left Eye Missing)"
 		id = "one_eyed_l"
 
@@ -368,10 +379,18 @@
 				if(ishuman(owner))
 					var/mob/living/carbon/human/H = owner
 					if(H.organHolder != null)
-						var/eyeball = H.organHolder.get_organ("left eye")
-						H.drop_organ(eyeball)
-						H.update_body()
-						qdel(eyeball)*/
+						var/eyeball = H.organHolder.left_eye
+						H.drop_organ("left_eye")
+						qdel(eyeball)
+
+		onRemove(var/mob/owner)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/H = owner
+				if(H.organHolder != null)
+					if (H.organHolder.left_eye != null)
+						return
+					else
+						H.receive_organ(/obj/item/organ/eye, "left_eye", 0, 1)
 
 /datum/trait/blind
 	name = "Blind"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -365,10 +365,8 @@
 
 					//give them an eyepatch
 					var/eyepatch = /obj/item/clothing/glasses/eyepatch
-					if (H.back?.storage && H.equip_if_possible(eyepatch, slot_in_backpack))
-
-					src.block_eye = "L"
-					src.icon_state = "eyepatch-L"
+					if (H.back?.storage)
+						H.back.storage += new eyepatch(src)
 
 	//to do: figure out some way of readding the eye when the trait is removed
 
@@ -384,6 +382,9 @@
 						var/eyeball = H.organHolder.left_eye
 						H.drop_organ("left_eye")
 						qdel(eyeball)
+
+						//src.block_eye = "L"
+						//src.icon_state = "eyepatch-L"
 
 /datum/trait/blind
 	name = "Blind"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new trait allowing players to spawn with only one eye. They can choose between left or right and start with a medical eyepatch to cover their missing eye; or their healthy one, if they're so inclined.

(Also shuffles things around in the trait file a bit, which I probably shouldn't have done, but it needs a refactor at some point anyhow.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Removes the need for people to rush to medical for eye removals at roundstart if they want to play without one.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(*)New trait - "One Eyed" - in left and right side variants.
```
