### PR TITLE
(Experimental) Medical xp is now factored into surgery success.

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -154,7 +154,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 			screw_up_prob -= 5
 
 	if (surgeon.traitHolder.hasTrait("training_medical"))
-		screw_up_prob = clamp(screw_up_prob, 0, 100) // if they're a doctor they can have no chance to mess up
+		screw_up_prob = clamp(screw_up_prob, (10 - clamp((get_level(surgeon.ckey, "Medical Doctor") * 2), 0, 10)), 100) // If they're a doctor, their minimum chance of messing up is relative to their job xp
 	else
 		screw_up_prob = clamp(screw_up_prob, 15, 100) // otherwise there'll always be a slight chance
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Having a higher doctoring level modifies the minimum possible failure chance for surgery steps. The default at level 0 but with medical training is 10, and this goes down by your level multiplied by two to an ultimate minimum of 0%. As this is only the minimum possible value and not the actual failure chance, failure mitigating/success chance improving measures still need to be taken.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Provides a use for medical xp.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(*)Medical xp is now factored into surgery success.
```
