### PR TITLE
Removes roboupgrades from the crate lootpool.

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -24,10 +24,6 @@
 	)
 	var/list/department = list(
 	// medbay
-		/obj/item/roboupgrade/efficiency = 20,\
-		/obj/item/roboupgrade/jetpack = 20,\
-		/obj/item/roboupgrade/physshield = 10,\
-		/obj/item/roboupgrade/teleport = 10,\
 		/obj/item/cloner_upgrade = 10,\
 		/obj/item/grinder_upgrade = 20,\
 		/obj/item/reagent_containers/mender/both = 10,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes roboupgrades from the crate lootpool.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Silicon removal.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TyrantCerberus
(+)Removes roboupgrades from the crate lootpool.
```
